### PR TITLE
fix: cast configcat.log.level into integer

### DIFF
--- a/src/ConfigCatServiceProvider.php
+++ b/src/ConfigCatServiceProvider.php
@@ -63,7 +63,7 @@ class ConfigCatServiceProvider extends ServiceProvider
                 ClientOptions::CACHE => new LaravelCache(Cache::store($app['config']['configcat.cache.store'])),
                 ClientOptions::CACHE_REFRESH_INTERVAL => $app['config']['configcat.cache.interval'],
                 ClientOptions::LOGGER => $logger,
-                ClientOptions::LOG_LEVEL => (int)$app['config']['configcat.log.level'],
+                ClientOptions::LOG_LEVEL => (int) $app['config']['configcat.log.level'],
                 ClientOptions::FLAG_OVERRIDES => $app['config']['configcat.overrides.enabled']
                     ? ConfigCat::overrides($app['config']['configcat.overrides.file'])
                     : null,


### PR DESCRIPTION
This could be a problem where this could be set via environment variables 
```.env
CONFIGCAT_LOG_LEVEL=50
```
which would correspond to 
```php
ConfigCat\Log\LogLevel::ERROR;
```
but would be interpreted as strings `"50"` instead of the value of the constant, which is an integer.
```php
<?php

namespace ConfigCat\Log;

class LogLevel
{
    // ...
    const ERROR = 50;
    // ...
}
```