### PR TITLE
fix: prevent ConfigCat::override() to be used in production

### DIFF
--- a/src/ConfigCat.php
+++ b/src/ConfigCat.php
@@ -95,7 +95,7 @@ class ConfigCat implements FeatureFlagProviderContract
      */
     public function override(array $flagsToOverride)
     {
-        if (app()->environment('testing') && $this->overridesFilePath) {
+        if (! app()->environment('production') && $this->overridesFilePath) {
             File::put(self::localFile($this->overridesFilePath), json_encode([
                 'flags' => $flagsToOverride,
             ]));


### PR DESCRIPTION
Instead of only allowing it to be used in `testing` environment, we're only making sure it's not used in `production` so it can also be used on other environments such as `dusk` or `staging`.